### PR TITLE
Automate the update process

### DIFF
--- a/.github/workflows/update-notifications.yml
+++ b/.github/workflows/update-notifications.yml
@@ -1,0 +1,46 @@
+# Watch the upstream version for changes and issue PRs when new versions are available.
+name: Watch for updates
+
+on:
+  push:
+    branches:
+      - feature/automate-updates
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  refresh-script:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Patch the current upstream version
+        shell: bash
+        run: bin/refresh-wp-install-tests.sh
+
+      - name: Check for differences
+        id: differences
+        run: echo "::set-output name=changes::"$(git diff --ignore-space-change --quiet bin/install-wp-tests.sh; echo $?)""
+
+      - name: Retrieve details from the WP-CLI repo
+        if: ${{ steps.differences.outputs.changes == '1' }}
+        id: upstream
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const commit = await github.rest.repos.listCommits({
+              owner: 'wp-cli',
+              repo: 'scaffold-command',
+              path: 'templates/install-wp-tests.sh',
+              per_page: 1
+            });
+            console.log(`::set-output name=ref::${commit.data[0].sha.substring(0, 8)}`);
+            console.log(`::set-output name=url::${commit.data[0].html_url}`);
+
+      - name: Submit PR
+        uses: technote-space/create-pr-action@v2
+        with:
+          COMMIT_MESSAGE: "Reference: ${{ steps.upstream.outputs.url }}"
+          PR_BRANCH_NAME: "update/${{ steps.upstream.outputs.ref }}"
+          PR_TITLE: "Update install-wp-tests.sh to match ${{ steps.upstream.outputs.ref }}"

--- a/.github/workflows/update-notifications.yml
+++ b/.github/workflows/update-notifications.yml
@@ -2,9 +2,6 @@
 name: Watch for updates
 
 on:
-  push:
-    branches:
-      - feature/automate-updates
   schedule:
     - cron: '0 12 * * *'
 

--- a/bin/refresh-wp-install-tests.sh
+++ b/bin/refresh-wp-install-tests.sh
@@ -11,4 +11,4 @@ curl -s "$upstream_src" | sed "2i\\
 # ${upstream_src}
 " > "${bin_dir}/install-wp-tests.sh" || exit 1
 
-printf "\033[0;32m%s %s\033[0;32m\n" 'bin/install-wp-tests.sh has been updated to match' "$upstream_src"
+printf '\033[0;32m%s %s\033[0;32m\n' 'bin/install-wp-tests.sh has been updated to match' "$upstream_src"

--- a/bin/refresh-wp-install-tests.sh
+++ b/bin/refresh-wp-install-tests.sh
@@ -2,10 +2,13 @@
 #
 # Refreshes the bin/install-wp-tests.sh file from source, injecting a comment at the top of the file.
 
-SRC="https://raw.githubusercontent.com/wp-cli/scaffold-command/master/templates/install-wp-tests.sh"
-DIR="$( cd "$(dirname "$0")" || exit 1; pwd -P )"
+upstream_src='https://raw.githubusercontent.com/wp-cli/scaffold-command/master/templates/install-wp-tests.sh'
+bin_dir="$(dirname "${BASH_SOURCE[0]}")"
 
-curl -s "$SRC" \
-    | sed $'2i\\\n# Notice: This file is pulled from the WP-CLI scaffold command,\\\n# and should not be modified directly.\n' \
-    > "$DIR/install-wp-tests.sh" \
-    && echo -e "\033[0;32mbin/install-wp-tests.sh has been updated to match ${SRC}\033[0;0m"
+curl -s "$upstream_src" | sed "2i\\
+# Notice: This file is pulled from the WP-CLI scaffold command, and should not be modified directly.\\
+#\\
+# ${upstream_src}
+" > "${bin_dir}/install-wp-tests.sh" || exit 1
+
+printf "\033[0;32m%s %s\033[0;32m\n" 'bin/install-wp-tests.sh has been updated to match' "$upstream_src"


### PR DESCRIPTION
This PR refactors the refresh script and introduces a GitHub action that runs once a day to check the upstream `install-wp-tests.sh` script for updates; if one is found, a PR is automatically opened against this repository.

Refs #1, closes #5.